### PR TITLE
lowercase usernames for comparison

### DIFF
--- a/cla_script.py
+++ b/cla_script.py
@@ -37,7 +37,7 @@ def main(repo, branch, dry_run=False):
     if dry_run:
         print("Doing a dry-run...\nNo changes will be applied to the repo")
 
-    extra_contributors = ['JarbasAl']
+    extra_contributors = ['jarbasal']
 
     contributors = get_contributors() + extra_contributors
     gh = Github(os.environ['GITHUB_ACCESS_TOKEN'])

--- a/cla_script.py
+++ b/cla_script.py
@@ -30,7 +30,7 @@ def get_contributors():
     # Everything after the --- break line
     contributors = contributors.split('---\n')[1]
     contributors = contributors.split('\n')
-    return [re.sub(r'(^.*\(|\))', '', c.strip()) for c in contributors]
+    return [re.sub(r'(^.*\(|\))', '', c.strip()).lower() for c in contributors]
 
 
 def main(repo, branch, dry_run=False):
@@ -51,7 +51,7 @@ def main(repo, branch, dry_run=False):
         if pr.created_at.date() < date(2019, 6, 6):
             continue
         print(u'\n\nChecking {} by {}:'.format(pr.title, pr.user.login))
-        if pr.user.login in contributors:
+        if pr.user.login.lower() in contributors:
             print(u'\t{} has signed the CLA'.format(pr.user.login))
 
             labels = list(pr.get_labels())


### PR DESCRIPTION
#### Description
Currently the check is case sensitive so a username of `JaneDoe` will not match if it's entered in the collaborators list as `janedoe`. 

There cannot be both a `JaneDoe` and `janedoe` account on Github.

#### Type of PR
- [x] Bugfix

#### Testing
Run the script on the latest commit to mycroft-core
NeonDaniel is on the list of contributors
without change - reported as CLA needed
after change - reported as CLA signed